### PR TITLE
Create ai-conv-how-is-wasm-runtime such as wasmtime-secure-sandboxed.md (deepseek)

### DIFF
--- a/ai-conv-how-is-wasm-runtime such as wasmtime-secure-sandboxed.md
+++ b/ai-conv-how-is-wasm-runtime such as wasmtime-secure-sandboxed.md
@@ -1,0 +1,56 @@
+# Conversations with AI and responses
+
+## Question
+
+when speaking of WASM there's always the wording of secure and sandboxed. How in fact is a wasm runtime such as wasmtime secure and sandboxed? Who vets the code for it being so? Is it just the fact that it's open source and anyone can read it, and hence there's the proof?
+
+## Response
+WebAssembly (WASM) runtimes like Wasmtime are designed to be secure and sandboxed by leveraging a combination of architectural principles, formal verification, open-source collaboration, and rigorous testing. Below is a detailed breakdown of how Wasmtime achieves security, who ensures its correctness, and why "open source" alone isn't the sole guarantee.
+
+---
+
+### **1. Core Sandboxing Mechanisms in WASM**
+WebAssembly’s design enforces sandboxing through:
+- **Memory Isolation**: WASM modules use linear memory, which is bounds-checked and isolated from the host system. Out-of-bounds accesses trap (terminate execution) rather than corrupt adjacent memory .
+- **Control-Flow Integrity (CFI)**: All calls (direct/indirect) are type-checked, and the call stack is protected, preventing code injection or ROP attacks .
+- **Capability-Based Access**: Modules can only interact with the host via explicitly imported functions (e.g., WASI for filesystem access). By default, they have no OS/system call privileges .
+- **No Undefined Behavior**: WASM’s semantics eliminate traditional C/C++ vulnerabilities (e.g., buffer overflows, use-after-free) by design .
+
+---
+
+### **2. How Wasmtime Enhances Security**
+Wasmtime, a popular WASM runtime, adds layers of defense:
+- **Rust Implementation**: Written in Rust, Wasmtime avoids memory-safety bugs (e.g., 70% of browser vulnerabilities are memory-related) .
+- **Spectre Mitigations**: Implements hardware-assisted protections against speculative execution attacks .
+- **Guard Pages & Zeroing Memory**: Uses guard regions to catch overflow bugs and zeroes memory between instances to prevent data leaks .
+- **WASI’s Capability Model**: Filesystem access is restricted to pre-approved directories, following least-privilege principles .
+
+---
+
+### **3. Who Vets the Code?**
+Security is ensured through multiple overlapping efforts:
+- **Formal Verification**: Projects like **vWasm** (from CMU) mathematically prove WASM compilers enforce sandboxing, eliminating implementation bugs .
+- **Fuzzing & Testing**: Wasmtime is continuously fuzzed (e.g., via OSS-Fuzz) to uncover edge cases. It also undergoes differential testing against other runtimes (e.g., V8) .
+- **Security Audits**: The Bytecode Alliance (Wasmtime’s maintainers) enforces strict code review, dependency audits (via `cargo vet`), and a documented security policy for vulnerabilities .
+- **Community Scrutiny**: As open-source, independent researchers and organizations (e.g., Google, Mozilla) contribute audits. For example, past CVEs (e.g., out-of-bounds writes) were patched promptly .
+
+---
+
+### **4. Is Open Source Alone Enough?**
+No. While open source enables transparency, security relies on:
+- **Active Maintenance**: Wasmtime’s team prioritizes security patches (e.g., Spectre fixes) and follows RFC processes for new features .
+- **Defense-in-Depth**: Even if a bug escapes review, mitigations (e.g., guard pages, CFI) limit exploit impact .
+- **Formal Methods**: Tools like F* (used in vWasm) provide mathematical guarantees beyond manual review .
+
+---
+
+### **5. Limitations and Risks**
+Despite these measures, risks remain:
+- **JIT Compiler Bugs**: Malicious WASM could exploit JIT vulnerabilities (e.g., crafted constants injecting x86 code) .
+- **Side Channels**: Timing attacks are possible if host APIs leak information .
+- **Supply Chain Risks**: Malicious dependencies (e.g., in Rust crates) are mitigated but not eliminated .
+
+---
+
+### **Conclusion**
+Wasmtime’s security stems from **design** (WASM’s sandboxing), **implementation** (Rust, formal verification), and **process** (fuzzing, audits). Open source is a foundation, but active maintenance, layered defenses, and academic collaboration (e.g., vWasm) are critical. For deeper dives, explore Wasmtime’s [security docs](https://docs.wasmtime.dev/security.html)  or the Bytecode Alliance’s [correctness blog](https://bytecodealliance.org/articles/security-and-correctness-in-wasmtime) .


### PR DESCRIPTION
when speaking of WASM there's always the wording of secure and sandboxed. How in fact is a wasm runtime such as wasmtime secure and sandboxed? Who vets the code for it being so? Is it just the fact that it's open source and anyone can read it, and hence there's the proof?